### PR TITLE
Custom Fields: Add codice fiscale input

### DIFF
--- a/extensions/ui-extension/locales/en.default.json
+++ b/extensions/ui-extension/locales/en.default.json
@@ -1,3 +1,6 @@
 {
-  "welcome": "Welcome to the {{extensionPoint}} extension!"
+   "codice_fiscale": {
+      "heading": "Codice Fiscale",
+      "label": "Codice Fiscale (optional)"
+   }
 }

--- a/extensions/ui-extension/locales/fr.json
+++ b/extensions/ui-extension/locales/fr.json
@@ -1,3 +1,1 @@
-{
-  "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
-}
+{}

--- a/extensions/ui-extension/src/fields/CodiceFiscale.tsx
+++ b/extensions/ui-extension/src/fields/CodiceFiscale.tsx
@@ -1,0 +1,26 @@
+import {
+   BlockStack,
+   Heading,
+   TextField,
+   useApplyAttributeChange,
+   useTranslate,
+} from "@shopify/checkout-ui-extensions-react";
+
+export function CodiceFiscale() {
+   const applyAttributeChange = useApplyAttributeChange();
+   const translate = useTranslate();
+   const applyCodiceFiscaleChange = (value: string) =>
+      applyAttributeChange({
+         key: "Codice Fiscale",
+         type: "updateAttribute",
+         value,
+      });
+   const heading = translate("codice_fiscale.heading");
+   const label = translate("codice_fiscale.label");
+   return (
+      <BlockStack>
+         <Heading>{heading}</Heading>
+         <TextField label={label} onChange={applyCodiceFiscaleChange} />
+      </BlockStack>
+   );
+}

--- a/extensions/ui-extension/src/fields/index.ts
+++ b/extensions/ui-extension/src/fields/index.ts
@@ -1,0 +1,1 @@
+export * from "./CodiceFiscale";

--- a/extensions/ui-extension/src/index.tsx
+++ b/extensions/ui-extension/src/index.tsx
@@ -1,19 +1,4 @@
-import React from 'react';
-import {
-  useExtensionApi,
-  render,
-  Banner,
-  useTranslate,
-} from '@shopify/checkout-ui-extensions-react';
+import { render } from "@shopify/checkout-ui-extensions-react";
+import { CodiceFiscale } from "./fields";
 
-render('Checkout::Dynamic::Render', () => <App />);
-
-function App() {
-  const {extensionPoint} = useExtensionApi();
-  const translate = useTranslate();
-  return (
-    <Banner title="ui-extension">
-      {translate('welcome', {extensionPoint})}
-    </Banner>
-  );
-}
+render("Checkout::Dynamic::Render", () => <CodiceFiscale />);


### PR DESCRIPTION
Closes #2 

Adds an optional codice fiscale input field. When populated, it adds the Codice Fiscale value as an attribute to the order.

## QA

- Clone the repo
- `cd` into it, `nvm use`, and `pnpm install`
- `pnpm dev` will start a development server. Click the link it generates.
- The "App home" url is the dev Shopify Admin for this app.
- The "ui-extension" url will take you to a checkout/fake store
- Append the query parameter `?placement-reference=PAYMENT4` to the url ([docs](https://shopify.dev/docs/apps/checkout/best-practices/testing-ui-extensions#test-locally))
- At the payment step of checkout, you should see a "Codice Fiscale" input field.
- On shopify-v2, this field is only visible if you're billing address country is Italy. On this feature, the field is always visible.
- After completing the order, the codice fiscale should be added to the order in shopify admin under "Additional Details".