### PR TITLE
Prevent invalid uses of `window`

### DIFF
--- a/extensions/ui-extension/tsconfig.json
+++ b/extensions/ui-extension/tsconfig.json
@@ -1,11 +1,12 @@
 {
-  // This tsconfig.json file is only needed to inform the IDE
-  // About the `react-jsx` tsconfig option, so IDE don't complain about missing react import
-  // Changing options here won't affect the build of your extension
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "esModuleInterop": true,
-    "strict": true
-  },
-  "include": ["./src"]
+   // This tsconfig.json file is only needed to inform the IDE
+   // About the `react-jsx` tsconfig option, so IDE don't complain about missing react import
+   // Changing options here won't affect the build of your extension
+   "compilerOptions": {
+      "jsx": "react-jsx",
+      "esModuleInterop": true,
+      "lib": ["WebWorker"],
+      "strict": true
+   },
+   "include": ["./src"]
 }


### PR DESCRIPTION
Tells typescript to complain if undefined globals, like `window`, are accessed in the ui extension. The `window` is undefined in checkout ui extensions since they run in web workers (I confirmed that it is indeed undefined when running a dev server).

https://shopify.dev/docs/api/checkout-ui-extensions/unstable/configuration#network-access
https://www.typescriptlang.org/tsconfig#lib

qa_req 0 if CI passes